### PR TITLE
Refactor Input Tag Story

### DIFF
--- a/src/components/InputTag/InputTag.js
+++ b/src/components/InputTag/InputTag.js
@@ -1,12 +1,12 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import {
   InputTagContainer,
   TagWrapper,
   OverFlowWrapper,
   InputField,
-  InputLabel,
-  InputMessage,
+  Label,
+  Message,
 } from "./InputTag.styled";
 import Tag from "../Tag/Tag";
 
@@ -16,11 +16,13 @@ const InputTag = ({
   errorMessage,
   descriptionMessage,
   tagsMaxCount,
+  handleDelete,
 }) => {
   const [inputState, setInputState] = useState("");
   const [errorMessageState, setErrorMessageState] = useState("");
   const [inputValue, setInputValue] = useState("");
   const [tags, setTags] = useState([]);
+  const inputRef = useRef();
 
   useEffect(() => {
     setInputState(inputStateValue);
@@ -93,35 +95,53 @@ const InputTag = ({
     setIsKeyReleased(true);
   };
 
+  // Focus the input field whenever the container is clicked
+  const handleFocusInput = () => {
+    inputRef.current.focus();
+  };
+
   return (
-    <InputTagContainer className="input-tag__container" inputState={inputState}>
+    <InputTagContainer
+      inputState={inputState}
+      onClick={() => handleFocusInput()}
+    >
       <OverFlowWrapper>
         <TagWrapper>
           {tags.map((tag, tagIdx) => (
-            <Tag key={tagIdx} label={tag}></Tag>
+            <Tag
+              key={tagIdx}
+              label={tag}
+              // pass handleClose function so that argTypes fires as intended for
+              // Tag story
+              handleClose={(e) => handleDelete(e)}
+            ></Tag>
           ))}
         </TagWrapper>
         <InputField
-          className="input__field"
-          id="inputId"
+          className="input-field"
+          id="input-id"
           placeholder=" "
           value={inputValue}
           onChange={(e) => handleInput(e)}
           onKeyDown={(e) => handleTags(e)}
           onKeyUp={(e) => handleKeyRelease(e)}
           disabled={inputState === "disabled" ? true : false}
+          ref={inputRef}
         />
-        <InputLabel className="input__label" for="inputId" tags={tags}>
+        <Label
+          className="label"
+          htmlFor="input-id"
+          tags={tags}
+          inputValue={inputValue}
+        >
           {label}
-        </InputLabel>
+        </Label>
       </OverFlowWrapper>
       {inputState === "error" && (
-        <InputMessage inputState={inputState}>{errorMessageState}</InputMessage>
+        <Message inputState={inputState}>{errorMessageState}</Message>
       )}
       {inputState === "description" && (
-        <InputMessage inputState={inputState}>
-          {descriptionMessage}
-        </InputMessage>
+        <Message inputState={inputState}>{descriptionMessage}</Message>
       )}
     </InputTagContainer>
   );

--- a/src/components/InputTag/InputTag.stories.js
+++ b/src/components/InputTag/InputTag.stories.js
@@ -3,6 +3,7 @@ import InputTag from "./InputTag";
 export default {
   title: "Components/InputTag",
   component: InputTag,
+  argTypes: { handleDelete: { action: "handleDelete" } },
 };
 
 const Template = (args) => <InputTag {...args} />;

--- a/src/components/InputTag/InputTag.styled.js
+++ b/src/components/InputTag/InputTag.styled.js
@@ -2,22 +2,22 @@ import styled from "styled-components";
 
 export const InputTagContainer = styled.div`
   background-color: ${(props) =>
-    props.inputState === "error" ? "#F9E3E3" : "#FFFFFF"};
+    props.inputState === "error"
+      ? props.theme.colorRedGirl
+      : props.theme.colorWhite};
+  cursor: text;
   position: relative;
   width: 482px;
   height: 56px;
   border-radius: 2px;
-  box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
-    0px 4px 16px rgba(51, 51, 51, 0.08);
+  box-shadow: ${(props) => props.theme.shadowDefault};
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 
   &:hover {
-    box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
-      0px 4px 56px rgba(51, 51, 51, 0.16);
+    box-shadow: ${(props) => props.theme.shadowHover};
   }
   &:focus-within {
-    box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
-      0px 4px 24px rgba(51, 51, 51, 0.24);
+    box-shadow: ${(props) => props.theme.shadowActive};
   }
 `;
 
@@ -51,11 +51,10 @@ export const InputField = styled.input.attrs({ type: "input" })`
   border: none;
   background: none;
   outline: none;
-  font-size: 16px;
-  line-height: 24px;
+  font: ${(props) => props.theme.fontParagraph2};
 
   &:disabled,
-  &:disabled ~ .input__label {
+  &:disabled ~ .label {
     cursor: not-allowed;
     color: rgba(17, 17, 17, 0.24);
   }
@@ -63,36 +62,39 @@ export const InputField = styled.input.attrs({ type: "input" })`
   &:focus {
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
   }
-  &:focus ~ .input__label,
-  &:not(:placeholder-shown).input__field:not(:focus) ~ .input__label {
+  &:focus ~ .label,
+  &:not(:placeholder-shown).input__field:not(:focus) ~ .label {
     opacity: 0;
   }
 
-  &:focus ~ .input {
+  /* &:focus ~ .input {
     box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
       0px 4px 24px rgba(51, 51, 51, 0.24);
   }
   &:active ~ .input {
     box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
       0px 4px 24px rgba(51, 51, 51, 0.24);
-  }
+  } */
 `;
 
-export const InputLabel = styled.label`
+export const Label = styled.label`
   position: absolute;
-  font-size: 16px;
+  font: ${(props) => props.theme.fontParagraph2};
   left: 16px;
-  top: 20px;
-  opacity: ${(props) => (props.tags.length ? "0" : "1")};
+  top: 16px;
+  display: ${(props) =>
+    props.tags.length || props.inputValue.length ? "none" : "inline"};
   cursor: text;
-  color: rgba(17, 17, 17, 0.48);
+  color: ${(props) => props.theme.colorGray};
 `;
 
-export const InputMessage = styled.label`
+export const Message = styled.label`
   position: absolute;
   top: 65px;
   left: 2px;
-  color: #db524e;
+  font: ${(props) => props.theme.fontParagraph2};
   color: ${(props) =>
-    props.inputState === "error" ? "#DB524E" : "rgba(17, 17, 17, 0.48)"};
+    props.inputState === "error"
+      ? props.theme.colorRed
+      : props.theme.colorGray};
 `;

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { TagContainer, Label, CloseIcon } from "./Tag.styled";
 
-const Tag = ({ label, size, handleClose }) => {
+const Tag = ({ label, size, handleClose, onClick }) => {
   return (
     <TagContainer size={size}>
       <Label>{label}</Label>


### PR DESCRIPTION
- Use theme values for styles
- Hide `Label` when there is an `inputValue`
- Focus `InputField` when container is clicked
- Set up `handleDelete` `argType` `action` for `Tag`
- Fix the `Label` blocking the close button on the first `Tag`