### PR TITLE
Minor adjustments and fixes

### DIFF
--- a/src/components/Files/Files.stories.js
+++ b/src/components/Files/Files.stories.js
@@ -20,7 +20,7 @@ Default.args = {
 
 export const Dragover = Template.bind({});
 Dragover.args = {
-  filesState: "dragover",
+  filesState: "dragOver",
   description:
     "PNG, jpg, gif files up to 10MB in size are available for upload",
   errorMessage: "The file size exceeded 10MB",

--- a/src/components/Filter/Filter.styled.js
+++ b/src/components/Filter/Filter.styled.js
@@ -22,17 +22,6 @@ const handleLabelBorderRadius = (position) => {
   }
 };
 
-const handleLabelBorderOverlap = (position) => {
-  switch (position) {
-    case "left":
-      return "0px 0px 0px 0px";
-    case "right":
-      return "0px 0px 0px 0px";
-    default:
-      return "0 0 0 0";
-  }
-};
-
 export const Label = styled.label`
   display: block;
   display: flex;
@@ -40,8 +29,6 @@ export const Label = styled.label`
   align-items: center;
   width: 96px;
   height: 56px;
-  /* margin: ${(props) => handleLabelBorderOverlap(props.position)}; */
-  /* margin: 0 -1px 0 -1px; */
   font: ${(props) => props.theme.fontParagraph2};
   border: 2px solid ${(props) => props.theme.colorGrayS};
   border-radius: ${(props) => handleLabelBorderRadius(props.position)};
@@ -57,7 +44,6 @@ export const InputField = styled.input.attrs({ type: "radio" })`
 
   &:checked ~ ${Label} {
     border: 2px solid ${(props) => props.theme.colorPrimary};
-    /* margin: ${(props) => handleLabelBorderOverlap(props.position)}; */
   }
 
   &:checked ~ ${Label}:hover {

--- a/src/components/InputTag/InputTag.js
+++ b/src/components/InputTag/InputTag.js
@@ -66,6 +66,7 @@ const InputTag = ({
       e.preventDefault();
       setTags((prevState) => [...prevState, trimmedInputValue]);
       setInputValue("");
+      setInputState("default");
     }
     // if the entered tag is already within the tags array, alert user with error
     else if (tags.includes(trimmedInputValue)) {
@@ -111,6 +112,7 @@ const InputTag = ({
             <Tag
               key={tagIdx}
               label={tag}
+              size={"medium"}
               // pass handleClose function so that argTypes fires as intended for
               // Tag story
               handleClose={(e) => handleDelete(e)}

--- a/src/components/InputTag/InputTag.styled.js
+++ b/src/components/InputTag/InputTag.styled.js
@@ -25,6 +25,7 @@ export const TagWrapper = styled.div`
   display: flex;
   gap: 4px;
   padding-right: 4px;
+  min-width: fit-content;
 `;
 
 export const OverFlowWrapper = styled.div`
@@ -46,8 +47,6 @@ export const InputField = styled.input.attrs({ type: "input" })`
   min-width: 80%;
   margin: 0;
   padding: 0;
-  top: 0;
-  left: 0;
   border: none;
   background: none;
   outline: none;
@@ -66,15 +65,6 @@ export const InputField = styled.input.attrs({ type: "input" })`
   &:not(:placeholder-shown).input__field:not(:focus) ~ .label {
     opacity: 0;
   }
-
-  /* &:focus ~ .input {
-    box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
-      0px 4px 24px rgba(51, 51, 51, 0.24);
-  }
-  &:active ~ .input {
-    box-shadow: 0px 4px 4px rgba(51, 51, 51, 0.04),
-      0px 4px 24px rgba(51, 51, 51, 0.24);
-  } */
 `;
 
 export const Label = styled.label`

--- a/src/components/Island/Island.styled.js
+++ b/src/components/Island/Island.styled.js
@@ -9,7 +9,6 @@ export const IslandContainer = styled.div`
   position: relative;
 
   box-sizing: border-box;
-  /* box-shadow: ${(props) => props.theme.boxShadow}; */
   overflow-clip-margin: -2px;
   overflow: hidden;
 `;
@@ -120,7 +119,6 @@ export const PenIcon = styled(Edit)`
 
 export const TextWrapper = styled.div`
   padding-top: ${(props) => (props.progressBar ? "16px" : "0")};
-  /* padding-top: 16px; */
   padding-bottom: 32px;
 `;
 
@@ -145,7 +143,6 @@ export const ProgressBar = styled.progress`
   top: 0;
   left: 0;
   background: #ffffff00;
-  /* opacity: 0; */
   border: none;
   height: 24px;
   width: 100%;

--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -26,7 +26,10 @@ export const Notification = ({
   handleHelp,
 }) => {
   return (
-    <NotificationContainer showButtons={showButtons}>
+    <NotificationContainer
+      showButtons={showButtons}
+      notificationState={notificationState}
+    >
       <FlexTopRow
         notificationState={notificationState}
         showHead={showHead}

--- a/src/components/Notification/Notification.styled.js
+++ b/src/components/Notification/Notification.styled.js
@@ -6,7 +6,8 @@ export const NotificationContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  width: 396px;
+  width: ${(props) =>
+    props.notificationState === "mobile" ? "306px" : "396px"};
   max-height: fit-content;
   box-sizing: border-box;
   box-shadow: ${(props) => props.theme.shadowDefault};

--- a/src/components/Popup/Popup.styled.js
+++ b/src/components/Popup/Popup.styled.js
@@ -11,8 +11,6 @@ export const PopupContainer = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  /* justify-content: flex-start;
-  align-items: flex-start; */
 
   justify-content: ${(props) =>
     props.popupState === "contact" ? "flex-start" : "center"};

--- a/src/components/Search/Search.styled.js
+++ b/src/components/Search/Search.styled.js
@@ -2,7 +2,6 @@ import styled, { css } from "styled-components";
 import { Search, Close } from "@styled-icons/material";
 
 export const SearchContainer = styled.div`
-  /* TODO: JH2021_12_23: sort out how I should do the gap */
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/src/components/SelectTag/SelectTag.js
+++ b/src/components/SelectTag/SelectTag.js
@@ -61,9 +61,15 @@ const SelectTag = ({ label, resultsArray, handleDelete }) => {
         // if the selected value is already in the tags array, remove the value from
         // the tags array
       } else {
-        const tagsCopy = [...lowerCaseTags];
-        const filteredTags = tagsCopy.filter((e) => e !== lowerCaseValue);
-        setTags(filteredTags);
+        const lowerCaseTagsCopy = [...lowerCaseTags];
+        const tagsCopy = [...tags];
+
+        // find the position of the tag to remove in the lowerCaseTags
+        const tagIdx = lowerCaseTagsCopy.findIndex((e) => e === lowerCaseValue);
+
+        // Remove the tagIdx from the non-lower case tagsCopy
+        tagsCopy.splice(tagIdx, 1);
+        setTags(tagsCopy);
       }
 
       // show the closeButton because inputRef will not cause a render for
@@ -212,7 +218,7 @@ const SelectTag = ({ label, resultsArray, handleDelete }) => {
               setResultsWindow(true);
             }}
           />
-          <Label className="label" forHtml="input-field" tags={tags}>
+          <Label className="label" htmlFor="input-field" tags={tags}>
             {label}
           </Label>
         </OverFlowWrapper>

--- a/src/components/SelectTag/SelectTag.styled.js
+++ b/src/components/SelectTag/SelectTag.styled.js
@@ -29,6 +29,7 @@ export const TagWrapper = styled.div`
   display: flex;
   gap: 4px;
   padding-right: 4px;
+  min-width: fit-content;
 `;
 
 export const InputField = styled.input.attrs({ type: "input" })`
@@ -37,8 +38,8 @@ export const InputField = styled.input.attrs({ type: "input" })`
   width: 100%;
   min-width: 80%;
   margin: 0;
+  padding: 0;
   border: none;
-  padding: 8px 66px 0 0px;
   background: none;
   outline: none;
   font: ${(props) => props.theme.fontParagraph2};

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { TagContainer, Label, CloseIcon } from "./Tag.styled";
 
-const Tag = ({ label, size, handleClose, onClick }) => {
+const Tag = ({ label, size, handleClose }) => {
   return (
     <TagContainer size={size}>
       <Label>{label}</Label>


### PR DESCRIPTION
- Fix Files dragover story not showing the correct state
- Change the width of Notification in mobile state to match the Figma
  file
- Add `min-width` to TagWrapper in InputTag and SelectTag to fix tag overflow when
  tags have spaces
- Turn off error state when input value is corrected InputTag
- Fix center alignment of SelectTag input field
- Remove unused `top` and `left` styles from InputTag input field
- Fix SelectTag overwriting tag case when unchecking a tag
- Delete unused CSS
- Fix SelectTag label `htmlFor`